### PR TITLE
Add ignoreNotFound command to the uninstall process

### DIFF
--- a/pkg/kubernetes/schema/schema.json
+++ b/pkg/kubernetes/schema/schema.json
@@ -32,26 +32,22 @@
             },
             "validate": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
             },
             "wait": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "upgradeStep": {
       "type": "object",
@@ -74,21 +70,21 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "prune": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "record": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
             "selector": {
               "type": "string"
@@ -96,31 +92,27 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "wait": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "invokeStep": {
       "type": "object",
@@ -143,21 +135,21 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "prune": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "record": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
             "selector": {
               "type": "string"
@@ -165,31 +157,27 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "wait": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "uninstallStep": {
       "type": "object",
@@ -212,9 +200,9 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "selector": {
@@ -223,24 +211,24 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "wait": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
+            },
+            "ignoreNotFound": {
+              "type": "boolean",
+              "default": "false"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "outputs": {
       "type": "array",

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -24,12 +24,13 @@ type UninstallArguments struct {
 	Namespace string   `yaml:"namespace"`
 	Manifests []string `yaml:"manifests,omitempty"`
 
-	Force       *bool  `yaml:force,omitempty"`
-	GracePeriod *int   `yaml:"gracePeriod,omitempty"`
-	Selector    string `yaml:"selector,omitempty"`
-	Context  string    `yaml:"context,omitempty"`
-	Timeout     *int   `yaml:"timeout,omitempty"`
-	Wait        *bool  `yaml:"wait,omitempty"`
+	Force          *bool  `yaml:force,omitempty"`
+	GracePeriod    *int   `yaml:"gracePeriod,omitempty"`
+	Selector       string `yaml:"selector,omitempty"`
+	Context        string `yaml:"context,omitempty"`
+	Timeout        *int   `yaml:"timeout,omitempty"`
+	Wait           *bool  `yaml:"wait,omitempty"`
+	IgnoreNotFound *bool  `yaml:"ignoreNotFound,omitempty"`
 }
 
 // Uninstall will delete anything created during the install or upgrade step
@@ -119,6 +120,14 @@ func (m *Mixin) buildUninstallCommand(args UninstallArguments, manifestPath stri
 	if args.Timeout != nil {
 		timeout := *args.Timeout
 		command = append(command, fmt.Sprintf("--timeout=%ds", timeout))
+	}
+
+	ignoreResourceNotFound := false
+	if args.IgnoreNotFound != nil {
+		ignoreResourceNotFound = *args.IgnoreNotFound
+	}
+	if ignoreResourceNotFound {
+		command = append(command, fmt.Sprintf("--ignore-not-found=%t", ignoreResourceNotFound))
 	}
 
 	waitForIt := true

--- a/pkg/kubernetes/uninstall_test.go
+++ b/pkg/kubernetes/uninstall_test.go
@@ -33,6 +33,7 @@ func TestMixin_UninstallStep(t *testing.T) {
 	withGrace := 1
 
 	timeout := 1
+	ignoreNotFound := true
 
 	uninstallTests := []UnInstallTest{
 		{
@@ -91,7 +92,7 @@ func TestMixin_UninstallStep(t *testing.T) {
 						Description: "Hello",
 					},
 					Manifests: []string{manifestDirectory},
-					Context:  context,
+					Context:   context,
 				},
 			},
 		},
@@ -128,6 +129,19 @@ func TestMixin_UninstallStep(t *testing.T) {
 					},
 					Manifests: []string{manifestDirectory},
 					Timeout:   &timeout,
+				},
+			},
+		},
+		// Insert the ignoreNotFound command
+		{
+			expectedCommand: fmt.Sprintf("%s %s --ignore-not-found=%t --wait", deleteCmd, manifestDirectory, ignoreNotFound),
+			uninstallStep: UninstallStep{
+				UninstallArguments: UninstallArguments{
+					Step: Step{
+						Description: "Hello",
+					},
+					Manifests:      []string{manifestDirectory},
+					IgnoreNotFound: &ignoreNotFound,
 				},
 			},
 		},


### PR DESCRIPTION
This will allow the user to define `ignoreNotFound` command and avoid the uninstall action of failing if the resource is not present

Close #25 