### PR TITLE
Make --ignore-not-found the default for uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ bin/porter$(FILE_EXT):
 	chmod +x bin/porter$(FILE_EXT)
 
 install:
-	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)
+	mkdir -p $(PORTER_HOME)/mixins/$(MIXIN)/runtimes
 	install $(BINDIR)/$(MIXIN)$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)$(FILE_EXT)
-	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/$(MIXIN)-runtime$(FILE_EXT)
+	install $(BINDIR)/$(MIXIN)-runtime$(FILE_EXT) $(PORTER_HOME)/mixins/$(MIXIN)/runtimes/$(MIXIN)-runtime$(FILE_EXT)
 
 clean: clean-packr
 	-rm -fr bin/

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ porter mixin install kubernetes --version $VERSION --url https://github.com/getp
 ### Mixin Configuration
 
 #### Kubernetes client version
+You can use the `clientVersion` field to specify the kubectl CLI version.
 
 ```yaml
 - kubernetes:
@@ -76,6 +77,8 @@ uninstall:
       manifests:
         - /cnab/app/manifests/hello
       wait: true
+
+\* Uninstall automatically applies the --ignore-not-found flag so that you can safely repeat the uninstall action without errors.
 
 ```
 

--- a/pkg/kubernetes/schema/schema.json
+++ b/pkg/kubernetes/schema/schema.json
@@ -32,22 +32,26 @@
             },
             "validate": {
               "type": "boolean",
-              "default": "true"
+              "default":"true"
             },
             "wait": {
               "type": "boolean",
-              "default": "true"
+              "default":"true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": ["description", "manifests"]
+          "required": [
+            "description", "manifests"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["kubernetes"]
+      "required": [
+        "kubernetes"
+      ]
     },
     "upgradeStep": {
       "type": "object",
@@ -70,21 +74,21 @@
               }
             },
             "force": {
-              "type": ["boolean", "null"]
+              "type": ["boolean","null"]
             },
-            "gracePeriod": {
+            "gracePeriod" : {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "prune": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "record": {
-              "type": ["boolean", "null"]
+              "type": ["boolean","null"]
             },
             "selector": {
               "type": "string"
@@ -92,27 +96,31 @@
             "context": {
               "type": "string"
             },
-            "timeout": {
+            "timeout" : {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "wait": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": ["description", "manifests"]
+          "required": [
+            "description", "manifests"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["kubernetes"]
+      "required": [
+        "kubernetes"
+      ]
     },
     "invokeStep": {
       "type": "object",
@@ -135,21 +143,21 @@
               }
             },
             "force": {
-              "type": ["boolean", "null"]
+              "type": ["boolean","null"]
             },
-            "gracePeriod": {
+            "gracePeriod" : {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "prune": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "record": {
-              "type": ["boolean", "null"]
+              "type": ["boolean","null"]
             },
             "selector": {
               "type": "string"
@@ -157,27 +165,31 @@
             "context": {
               "type": "string"
             },
-            "timeout": {
+            "timeout" : {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "wait": {
-              "type": ["boolean", "null"],
-              "default": "true"
+              "type": ["boolean","null"],
+              "default":"true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": ["description", "manifests"]
+          "required": [
+            "description", "manifests"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["kubernetes"]
+      "required": [
+        "kubernetes"
+      ]
     },
     "uninstallStep": {
       "type": "object",
@@ -200,9 +212,9 @@
               }
             },
             "force": {
-              "type": ["boolean", "null"]
+              "type": ["boolean","null"]
             },
-            "gracePeriod": {
+            "gracePeriod" : {
               "type": "integer"
             },
             "selector": {
@@ -211,24 +223,24 @@
             "context": {
               "type": "string"
             },
-            "timeout": {
+            "timeout" : {
               "type": "integer"
             },
             "wait": {
               "type": "boolean",
-              "default": "true"
-            },
-            "ignoreNotFound": {
-              "type": "boolean",
-              "default": "false"
+              "default":"true"
             }
           },
           "additionalProperties": false,
-          "required": ["description", "manifests"]
+          "required": [
+            "description", "manifests"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["kubernetes"]
+      "required": [
+        "kubernetes"
+      ]
     },
     "outputs": {
       "type": "array",

--- a/pkg/kubernetes/schema/schema.json
+++ b/pkg/kubernetes/schema/schema.json
@@ -32,26 +32,22 @@
             },
             "validate": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
             },
             "wait": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "upgradeStep": {
       "type": "object",
@@ -74,21 +70,21 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "prune": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "record": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
             "selector": {
               "type": "string"
@@ -96,31 +92,27 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "wait": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "invokeStep": {
       "type": "object",
@@ -143,21 +135,21 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "overwrite": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "prune": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "record": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
             "selector": {
               "type": "string"
@@ -165,31 +157,27 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "validate": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "wait": {
-              "type": ["boolean","null"],
-              "default":"true"
+              "type": ["boolean", "null"],
+              "default": "true"
             },
             "outputs": {
               "$ref": "#/definitions/outputs"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "uninstallStep": {
       "type": "object",
@@ -212,9 +200,9 @@
               }
             },
             "force": {
-              "type": ["boolean","null"]
+              "type": ["boolean", "null"]
             },
-            "gracePeriod" : {
+            "gracePeriod": {
               "type": "integer"
             },
             "selector": {
@@ -223,24 +211,24 @@
             "context": {
               "type": "string"
             },
-            "timeout" : {
+            "timeout": {
               "type": "integer"
             },
             "wait": {
               "type": "boolean",
-              "default":"true"
+              "default": "true"
+            },
+            "ignoreNotFound": {
+              "type": "boolean",
+              "default": "false"
             }
           },
           "additionalProperties": false,
-          "required": [
-            "description", "manifests"
-          ]
+          "required": ["description", "manifests"]
         }
       },
       "additionalProperties": false,
-      "required": [
-        "kubernetes"
-      ]
+      "required": ["kubernetes"]
     },
     "outputs": {
       "type": "array",

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -24,12 +24,13 @@ type UninstallArguments struct {
 	Namespace string   `yaml:"namespace"`
 	Manifests []string `yaml:"manifests,omitempty"`
 
-	Force       *bool  `yaml:force,omitempty"`
-	GracePeriod *int   `yaml:"gracePeriod,omitempty"`
-	Selector    string `yaml:"selector,omitempty"`
-	Context  string    `yaml:"context,omitempty"`
-	Timeout     *int   `yaml:"timeout,omitempty"`
-	Wait        *bool  `yaml:"wait,omitempty"`
+	Force          *bool  `yaml:force,omitempty"`
+	GracePeriod    *int   `yaml:"gracePeriod,omitempty"`
+	Selector       string `yaml:"selector,omitempty"`
+	Context        string `yaml:"context,omitempty"`
+	Timeout        *int   `yaml:"timeout,omitempty"`
+	Wait           *bool  `yaml:"wait,omitempty"`
+	IgnoreNotFound *bool  `yaml:"ignoreNotFound,omitempty"`
 }
 
 // Uninstall will delete anything created during the install or upgrade step
@@ -119,6 +120,14 @@ func (m *Mixin) buildUninstallCommand(args UninstallArguments, manifestPath stri
 	if args.Timeout != nil {
 		timeout := *args.Timeout
 		command = append(command, fmt.Sprintf("--timeout=%ds", timeout))
+	}
+
+	ignoreResourceNotFound := false
+	if args.IgnoreNotFound != nil {
+		ignoreResourceNotFound = *args.IgnoreNotFound
+	}
+	if ignoreResourceNotFound {
+		command = append(command, fmt.Sprintf("--ignore-not-found=%t", ignoreResourceNotFound))
 	}
 
 	waitForIt := true

--- a/pkg/kubernetes/uninstall.go
+++ b/pkg/kubernetes/uninstall.go
@@ -30,7 +30,6 @@ type UninstallArguments struct {
 	Context        string `yaml:"context,omitempty"`
 	Timeout        *int   `yaml:"timeout,omitempty"`
 	Wait           *bool  `yaml:"wait,omitempty"`
-	IgnoreNotFound *bool  `yaml:"ignoreNotFound,omitempty"`
 }
 
 // Uninstall will delete anything created during the install or upgrade step
@@ -80,7 +79,7 @@ func (m *Mixin) Uninstall() error {
 }
 
 func (m *Mixin) buildUninstallCommand(args UninstallArguments, manifestPath string) ([]string, error) {
-	command := []string{"delete", "-f", manifestPath}
+	command := []string{"delete", "--ignore-not-found=true", "-f", manifestPath}
 	if args.Namespace != "" {
 		command = append(command, "-n", args.Namespace)
 	}
@@ -120,14 +119,6 @@ func (m *Mixin) buildUninstallCommand(args UninstallArguments, manifestPath stri
 	if args.Timeout != nil {
 		timeout := *args.Timeout
 		command = append(command, fmt.Sprintf("--timeout=%ds", timeout))
-	}
-
-	ignoreResourceNotFound := false
-	if args.IgnoreNotFound != nil {
-		ignoreResourceNotFound = *args.IgnoreNotFound
-	}
-	if ignoreResourceNotFound {
-		command = append(command, fmt.Sprintf("--ignore-not-found=%t", ignoreResourceNotFound))
 	}
 
 	waitForIt := true

--- a/pkg/kubernetes/uninstall_test.go
+++ b/pkg/kubernetes/uninstall_test.go
@@ -33,6 +33,7 @@ func TestMixin_UninstallStep(t *testing.T) {
 	withGrace := 1
 
 	timeout := 1
+	ignoreNotFound := true
 
 	uninstallTests := []UnInstallTest{
 		{
@@ -91,7 +92,7 @@ func TestMixin_UninstallStep(t *testing.T) {
 						Description: "Hello",
 					},
 					Manifests: []string{manifestDirectory},
-					Context:  context,
+					Context:   context,
 				},
 			},
 		},
@@ -128,6 +129,19 @@ func TestMixin_UninstallStep(t *testing.T) {
 					},
 					Manifests: []string{manifestDirectory},
 					Timeout:   &timeout,
+				},
+			},
+		},
+		// Insert the ignoreNotFound command
+		{
+			expectedCommand: fmt.Sprintf("%s %s --ignore-not-found=%t --wait", deleteCmd, manifestDirectory, ignoreNotFound),
+			uninstallStep: UninstallStep{
+				UninstallArguments: UninstallArguments{
+					Step: Step{
+						Description: "Hello",
+					},
+					Manifests:      []string{manifestDirectory},
+					IgnoreNotFound: &ignoreNotFound,
 				},
 			},
 		},

--- a/pkg/kubernetes/uninstall_test.go
+++ b/pkg/kubernetes/uninstall_test.go
@@ -21,7 +21,7 @@ func TestMixin_UninstallStep(t *testing.T) {
 
 	manifestDirectory := "/cnab/app/manifests"
 
-	deleteCmd := "kubectl delete -f"
+	deleteCmd := "kubectl delete --ignore-not-found=true -f"
 
 	dontWait := false
 
@@ -33,7 +33,6 @@ func TestMixin_UninstallStep(t *testing.T) {
 	withGrace := 1
 
 	timeout := 1
-	ignoreNotFound := true
 
 	uninstallTests := []UnInstallTest{
 		{
@@ -129,19 +128,6 @@ func TestMixin_UninstallStep(t *testing.T) {
 					},
 					Manifests: []string{manifestDirectory},
 					Timeout:   &timeout,
-				},
-			},
-		},
-		// Insert the ignoreNotFound command
-		{
-			expectedCommand: fmt.Sprintf("%s %s --ignore-not-found=%t --wait", deleteCmd, manifestDirectory, ignoreNotFound),
-			uninstallStep: UninstallStep{
-				UninstallArguments: UninstallArguments{
-					Step: Step{
-						Description: "Hello",
-					},
-					Manifests:      []string{manifestDirectory},
-					IgnoreNotFound: &ignoreNotFound,
 				},
 			},
 		},


### PR DESCRIPTION
This takes the work from #26 and makes `--ignore-not-found` the default. It should always be safe to repeat the uninstall command. This makes our uninstall more idempotnent by always including `--ignore-not-found=true` when running kubectl delete.

Closes #25 