### PR TITLE
Fix mixin feed publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,7 @@ test-integration: xbuild
 	$(GO) test -tags=integration ./tests/...
 
 publish: bin/porter$(FILE_EXT)
-	go run mage.go PublishMixin kubernetes $(VERSION) $(PERMALINK)
-	go run mage.go PublishMixinFeed
+	go run mage.go Publish $(MIXIN) $(VERSION) $(PERMALINK)
 
 bin/porter$(FILE_EXT):
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 replace github.com/hashicorp/go-plugin => github.com/carolynvs/go-plugin v1.0.1-acceptstdin
 
 require (
-	get.porter.sh/porter v0.34.0
+	get.porter.sh/porter v0.34.3
 	github.com/Masterminds/semver v1.5.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gobuffalo/packr/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.39.0/go.mod h1:rVLT6fkc8chs9sfPtFc1SBH6em7n+ZoXaG+87tDISts=
-get.porter.sh/porter v0.34.0 h1:TieCC8C7QUbRM7kUEj+d+++8GCy+4nWiXaaOGAXDNkg=
-get.porter.sh/porter v0.34.0/go.mod h1:5HvvZlBgSIyCUctXFiiEiqoGyD4YtzW1ydsXVHH/8go=
+get.porter.sh/porter v0.34.3 h1:DqusYABIwqYd3VwvxGjdhIopVnjSdI4O32zQnT7cNG0=
+get.porter.sh/porter v0.34.3/go.mod h1:5HvvZlBgSIyCUctXFiiEiqoGyD4YtzW1ydsXVHH/8go=
 github.com/Azure/azure-sdk-for-go v19.1.1+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v10.15.5+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=

--- a/magefile.go
+++ b/magefile.go
@@ -2,7 +2,18 @@
 
 package main
 
-// mage:import
-import _ "get.porter.sh/porter/mage/releases"
+import (
+	"context"
+
+	// mage:import
+	"get.porter.sh/porter/mage/releases"
+)
 
 // We are migrating to mage, but for now keep using make as the main build script interface.
+
+// Publish the cross-compiled binaries.
+func Publish(ctx context.Context, mixin string, version string, permalink string) {
+	releases.PrepareMixinForPublish(mixin, version, permalink)
+	releases.PublishMixin(mixin, version, permalink)
+	releases.PublishMixinFeed(ctx)
+}


### PR DESCRIPTION
Do not publish latest or untagged release to mixin feed.
See https://github.com/getporter/porter/pull/1466 for more context.