### PR TITLE
Fix publish after bumping Porter version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-integration: xbuild
 	$(GO) test -tags=integration ./tests/...
 
 publish: bin/porter$(FILE_EXT)
-	go run mage.go Publish $(MIXIN) $(VERSION) $(PERMALINK)
+	go run mage.go Publish $(MIXIN)
 
 bin/porter$(FILE_EXT):
 	curl -fsSLo bin/porter$(FILE_EXT) https://cdn.porter.sh/canary/porter-$(CLIENT_PLATFORM)-$(CLIENT_ARCH)$(FILE_EXT)

--- a/magefile.go
+++ b/magefile.go
@@ -10,8 +10,8 @@ import (
 // We are migrating to mage, but for now keep using make as the main build script interface.
 
 // Publish the cross-compiled binaries.
-func Publish(mixin string, version string, permalink string) {
-	releases.PrepareMixinForPublish(mixin, version, permalink)
-	releases.PublishMixin(mixin, version, permalink)
-	releases.PublishMixinFeed(mixin, version)
+func Publish(mixin string) {
+	releases.PrepareMixinForPublish(mixin)
+	releases.PublishMixin(mixin)
+	releases.PublishMixinFeed(mixin)
 }


### PR DESCRIPTION
When I bumped the Porter version, I didn't realize that this picked up a breaking change in some of the utility methods used in our magefile for publish. I've updated our magefile to use the new method signatures.

I tested this locally against my own forks to verify that publish is working again.

* https://github.com/carolynvs/kubernetes-mixin/releases/tag/canary
* https://github.com/carolynvs/porter-packages/commit/ca7877bd7b43881ecc880a700dc829f829d0628b