### PR TITLE
Use different kuberntes version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can use the `clientVersion` field to specify the kubectl CLI version.
 
 ```yaml
 - kubernetes:
-    clientVersion: v1.15.5
+    clientVersion: v1.20.13
 ```
 
 ### Mixin Actions Syntax


### PR DESCRIPTION
This is my first PR for this repo, so please let me know if I need to follow any process. 

### What is I am trying to fix and why:

I found this bug when I recently used this mixin for a porter bundle for one of service within aks.

* What I found is that the version which is recommended in the read me has the bug which will cause an `non-idempotent` behaviour because it was in older version of `kubectl`. more detail of that bug here: https://github.com/kubernetes/kubernetes/issues/92867 or https://github.com/kubernetes/kubernetes/issues/91615 

Hence raising quick change in ReadMe for any N00b like me not to fall into the trap of that bug which is fixed in latter versions.

Thanks. cc: @itowlson or @carolynvs ❤️🙏☕️ Thank you so much and wish you all an amazing New Years.