### PR TITLE
Encourage people to use latest kubectl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can use the `clientVersion` field to specify the kubectl CLI version.
 
 ```yaml
 - kubernetes:
-    clientVersion: v1.20.13
+    clientVersion: v1.20.13 # Replace this value with the latest patched version of kubectl
 ```
 
 ### Mixin Actions Syntax


### PR DESCRIPTION
Per #37, it seems that people may assume that the value in the readme is what people should use. It was only meant as an example. I've added a comment prompting people to specify the latest patched version of kubectl since the readme will always lag behind k8s releases.