### PR TITLE
Define configuration in the mixin schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ replace (
 require (
 	get.porter.sh/porter v1.0.0-alpha.13
 	github.com/Masterminds/semver v1.5.0
+	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/ghodss/yaml v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.1.3
@@ -29,7 +30,6 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/PaesslerAG/gval v1.0.0 // indirect
-	github.com/PaesslerAG/jsonpath v0.1.1 // indirect
 	github.com/PuerkitoBio/goquery v1.5.0 // indirect
 	github.com/andybalholm/brotli v1.0.0 // indirect
 	github.com/andybalholm/cascadia v1.0.0 // indirect

--- a/pkg/kubernetes/schema/schema.json
+++ b/pkg/kubernetes/schema/schema.json
@@ -1,8 +1,18 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "declaration": {
+      "oneOf": [
+        {
+          "description": "Declare the kubernetes mixin without configuration",
+          "type": "string",
+          "enum": ["kubernetes"]
+        },
+        {"$ref": "#/definitions/config"}
+      ]
+    },
     "config": {
-      "description": "Configuration that can be set when the mixin is declared",
+      "description": "Declare the kubernetes mixin with additional configuration",
       "type": "object",
       "properties": {
         "kubernetes": {
@@ -318,6 +328,10 @@
       "items": {
         "$ref": "#/definitions/uninstallStep"
       }
+    },
+    "mixins": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/declaration" }
     }
   },
   "additionalProperties": {

--- a/pkg/kubernetes/schema/schema.json
+++ b/pkg/kubernetes/schema/schema.json
@@ -1,6 +1,25 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "config": {
+      "description": "Configuration that can be set when the mixin is declared",
+      "type": "object",
+      "properties": {
+        "kubernetes": {
+          "description": "kubernetes mixin configuration",
+          "type": "object",
+          "properties": {
+            "clientVersion": {
+              "description": "Version of kubectl to install in the bundle",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false,
+      "required": ["kubernetes"]
+    },
     "installStep": {
       "type": "object",
       "properties": {

--- a/pkg/kubernetes/schema_test.go
+++ b/pkg/kubernetes/schema_test.go
@@ -1,10 +1,12 @@
 package kubernetes
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"testing"
 
-	// We are not using go-yaml because of serialization problems with jsonschema, don't use this library elsewhere
+	"github.com/PaesslerAG/jsonpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -21,6 +23,40 @@ func TestMixin_PrintSchema(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, string(wantSchema), gotSchema)
+}
+
+func TestMixin_CheckSchema(t *testing.T) {
+	// Long term it would be great to have a helper function in Porter that a mixin can use to check that it meets certain interfaces
+	// check that certain characteristics of the schema that Porter expects are present
+	// Once we have a mixin library, that would be a good place to package up this type of helper function
+	var schemaMap map[string]interface{}
+	err := json.Unmarshal([]byte(schema), &schemaMap)
+	require.NoError(t, err, "could not unmarshal the schema into a map")
+
+	t.Run("mixin configuration", func(t *testing.T) {
+		// Check that mixin config is defined, and has all the supported fields
+		configSchema, err := jsonpath.Get("$.definitions.config", schemaMap)
+		require.NoError(t, err, "could not find the mixin config schema declaration")
+		_, err = jsonpath.Get("$.properties.kubernetes.properties.clientVersion", configSchema)
+		require.NoError(t, err, "client version was not included in the mixin config schema")
+	})
+
+	// Check that schema are defined for each action
+	actions := []string{"install", "upgrade", "invoke", "uninstall"}
+	for _, action := range actions {
+		t.Run("supports "+action, func(t *testing.T) {
+			actionPath := fmt.Sprintf("$.definitions.%sStep", action)
+			_, err := jsonpath.Get(actionPath, schemaMap)
+			require.NoErrorf(t, err, "could not find the %sStep declaration", action)
+		})
+	}
+
+	// Check that the invoke action is registered
+	additionalSchema, err := jsonpath.Get("$.additionalProperties.items", schemaMap)
+	require.NoError(t, err, "the invoke action was not registered in the schema")
+	require.Contains(t, additionalSchema, "$ref")
+	invokeRef := additionalSchema.(map[string]interface{})["$ref"]
+	require.Equal(t, "#/definitions/invokeStep", invokeRef, "the invoke action was not registered correctly")
 }
 
 func TestMixin_ValidatePayload(t *testing.T) {


### PR DESCRIPTION
This defines the configuration supported by the mixin when declaring it in a porter.yaml

```yaml
mixins:
  - kubernetes:
      clientVersion: 1.2.3
```

Porter checks for definitions.config and if present will ensure that the final schema for the porter.yaml includes the mixin's configuration schema so that when people using VS Code declare the mixin like above, they don't get red squiggles and instead get autocomplete.
